### PR TITLE
chore: update test URLs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apk add --update git python build-base && \
 COPY . .
 
 # TODO:
-ARG BASE_PATH="http://django-business-logic.dgk.su/business-logic/rest"
+ARG BASE_PATH="https://django-business-logic-demo.dev.dgk.su/business-logic/rest"
 #ARG BASE_PATH="/business-logic/rest"
 
 #RUN ( export BASE_PATH=$BASE_PATH ; yarn run test && yarn run bla-bla && .. && yarn run build )

--- a/src/config/routes.js
+++ b/src/config/routes.js
@@ -1,4 +1,4 @@
 export default {
-  API_ROOT: 'http://vzr.dgk.su',
-  API_BACKUP: 'http://django-business-logic.dgk.su',
+  API_ROOT: 'https://django-business-logic-demo.dev.dgk.su',
+  API_BACKUP: 'https://django-business-logic-demo.dev.dgk.su',
 }


### PR DESCRIPTION
## Summary
- replace test API URLs with https://django-business-logic-demo.dev.dgk.su
- update Dockerfile BASE_PATH to new demo domain

## Testing
- `npm test` *(fails: Cannot find module 'jest')*
- `npm install` *(fails: `make` failed with exit code 2)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c1bf4058833081354482740611c0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Switched API endpoints to use HTTPS on the demo domain for primary and backup connections, improving connection security and consistency.
  - Aligned build-time base path with the new HTTPS endpoint to match runtime configuration.

- Bug Fixes
  - Resolved potential mixed-content and connectivity issues by replacing HTTP endpoints with HTTPS equivalents.

- Documentation
  - N/A

- Tests
  - N/A

- Refactor
  - N/A

- Style
  - N/A

- Revert
  - N/A

<!-- end of auto-generated comment: release notes by coderabbit.ai -->