### PR TITLE
Add Interface MST store and hook integration

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=https://django-business-logic-demo.dev.dgk.su/business-logic

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "axios": "^1.11.0",
         "mobx": "^6.13.7",
         "mobx-react-lite": "^4.1.0",
+        "mobx-state-tree": "^6.0.1",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-router-dom": "^7.8.2"
@@ -2606,6 +2607,15 @@
         "react-native": {
           "optional": true
         }
+      }
+    },
+    "node_modules/mobx-state-tree": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/mobx-state-tree/-/mobx-state-tree-6.0.1.tgz",
+      "integrity": "sha512-ZmC90+aaZj4Tvwz/G8kihAcZzejiHfkaIrwyneH7ACoZwWY2Gw5SP1mPPPQbVehsXJ8/OhDT4cPUvvzy//+Qog==",
+      "license": "MIT",
+      "peerDependencies": {
+        "mobx": "^6.3.0"
       }
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "axios": "^1.11.0",
     "mobx": "^6.13.7",
     "mobx-react-lite": "^4.1.0",
+    "mobx-state-tree": "^6.0.1",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-router-dom": "^7.8.2"

--- a/src/models/Interface.ts
+++ b/src/models/Interface.ts
@@ -1,0 +1,47 @@
+import { types, flow, cast, Instance, SnapshotIn } from 'mobx-state-tree'
+import { callApi } from '../utils/api'
+
+export const InterfaceDataItemModel = types.model('InterfaceDataItem', {
+  code: types.maybeNull(types.string),
+  creation_time: types.string,
+  environment: types.number,
+  id: types.number,
+  modification_time: types.string,
+  title: types.string,
+  url: types.string,
+})
+
+export interface InterfaceDataItem extends Instance<typeof InterfaceDataItemModel> {}
+export interface InterfaceDataItemSnapshot extends SnapshotIn<typeof InterfaceDataItemModel> {}
+
+export const InterfaceStoreModel = types
+  .model('InterfaceStore', {
+    isFetching: types.boolean,
+    error: types.maybeNull(types.string),
+    data: types.array(InterfaceDataItemModel),
+  })
+  .actions(self => ({
+    setData(data: InterfaceDataItemSnapshot[]) {
+      self.data = cast(data)
+    },
+    setFetching(fetchState: boolean) {
+      self.isFetching = fetchState
+    },
+    setError(error: string | null) {
+      self.error = error
+    },
+    fetch: flow(function* fetch() {
+      try {
+        yield callApi<{ data: { results: InterfaceDataItemSnapshot[] } }>({
+          url: '/rest/program-interface',
+          onRequest: () => self.setFetching(true),
+          onSuccess: json => self.setData(json.data.results),
+          onError: err => self.setError(err),
+        })
+      } finally {
+        self.setFetching(false)
+      }
+    }),
+  }))
+
+export interface InterfaceStore extends Instance<typeof InterfaceStoreModel> {}

--- a/src/models/index.tsx
+++ b/src/models/index.tsx
@@ -2,9 +2,11 @@ import { createContext, useContext, ReactNode } from 'react'
 import { useLocalObservable } from 'mobx-react-lite'
 
 import { RouterStore } from './Router'
+import { InterfaceStoreModel, InterfaceStore } from './Interface'
 
 export interface RootStore {
   router: RouterStore
+  interfaceStore: InterfaceStore
 }
 
 const RootStoreContext = createContext<RootStore | null>(null)
@@ -12,6 +14,11 @@ const RootStoreContext = createContext<RootStore | null>(null)
 export function RootStoreProvider({ children }: { children: ReactNode }) {
   const store = useLocalObservable<RootStore>(() => ({
     router: new RouterStore(),
+    interfaceStore: InterfaceStoreModel.create({
+      isFetching: false,
+      error: null,
+      data: [],
+    }),
   }))
   return (
     <RootStoreContext.Provider value={store}>{children}</RootStoreContext.Provider>
@@ -24,4 +31,8 @@ export function useRootStore(): RootStore {
     throw new Error('useRootStore must be used within RootStoreProvider')
   }
   return store
+}
+
+export function useInterfaceStore(): InterfaceStore {
+  return useRootStore().interfaceStore
 }

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,5 +1,16 @@
 import axios, { AxiosRequestConfig } from 'axios'
 
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || ''
+
+const resolveUrl = (url: string): string => {
+  if (/^https?:\/\//.test(url)) {
+    return url
+  }
+  const base = API_BASE_URL.replace(/\/$/, '')
+  const path = url.replace(/^\//, '')
+  return `${base}/${path}`
+}
+
 export interface CallApiParams<T> {
   url: string
   config?: AxiosRequestConfig
@@ -10,10 +21,10 @@ export interface CallApiParams<T> {
 
 export const getResult = <T>(
   url: string,
-  config: AxiosRequestConfig = {}
+  config: AxiosRequestConfig = {},
 ): Promise<T> => {
   return axios
-    .get<T>(url, { crossDomain: true, ...config })
+    .get<T>(resolveUrl(url), { crossDomain: true, ...config })
     .then(response => response.data)
 }
 


### PR DESCRIPTION
## Summary
- migrate Interface model to MST 6 with TypeScript
- wire Interface store into RootStoreProvider and expose `useInterfaceStore`
- add `mobx-state-tree` dependency
- resolve API base URL at build time and fetch interface data via relative paths

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0dbf690e883309c9052781f989850