### PR TITLE
fix router nesting and add error boundary

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,32 @@
+import { Component, ErrorInfo, ReactNode } from 'react'
+
+interface Props {
+  children: ReactNode
+}
+
+interface State {
+  hasError: boolean
+}
+
+class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false }
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    // You can log the error to an error reporting service
+    console.error('Uncaught error:', error, errorInfo)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <div>Something went wrong.</div>
+    }
+
+    return this.props.children
+  }
+}
+
+export default ErrorBoundary

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,17 +1,17 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import { BrowserRouter } from 'react-router-dom'
 import 'semantic-ui-css/semantic.min.css'
 import './index.css'
 import App from './App.tsx'
 import { RootStoreProvider } from './models'
+import ErrorBoundary from './components/ErrorBoundary'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <BrowserRouter>
+    <ErrorBoundary>
       <RootStoreProvider>
         <App />
       </RootStoreProvider>
-    </BrowserRouter>
+    </ErrorBoundary>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- remove extra BrowserRouter to avoid nested Router error
- add reusable ErrorBoundary component and use at app root

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1482c55948330b92bbec94a89878c