### PR TITLE
Proxy business logic API through Vite dev server

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,4 +4,13 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/business-logic': {
+        target: 'https://django-business-logic-demo.dev.dgk.su',
+        changeOrigin: true,
+        secure: false,
+      },
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- configure Vite dev server to proxy `/business-logic` requests to the demo backend

## Testing
- `npm run lint`
- `npm run dev` *(failed to run dependency scan on first attempt; reran after installing dependencies; dev server started successfully)*

------
https://chatgpt.com/codex/tasks/task_e_68b14ae4017083308a3c2142dcc38649