### PR TITLE
Adjust interface fetch data parsing

### DIFF
--- a/src/models/Interface.ts
+++ b/src/models/Interface.ts
@@ -32,10 +32,10 @@ export const InterfaceStoreModel = types
     },
     fetch: flow(function* fetch() {
       try {
-        yield callApi<{ data: { results: InterfaceDataItemSnapshot[] } }>({
+        yield callApi<{ results: InterfaceDataItemSnapshot[] }>({
           url: '/rest/program-interface',
           onRequest: () => self.setFetching(true),
-          onSuccess: json => self.setData(json.data.results),
+          onSuccess: json => self.setData(json.results ?? []),
           onError: err => self.setError(err),
         })
       } finally {


### PR DESCRIPTION
## Summary
- simplify Interface model fetch parsing by expecting `results` at root and defaulting to an empty list

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b14f3ff0f48330bb448cd15d817080