### PR TITLE
feat: format interface modification date using dayjs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "axios": "^1.11.0",
+        "dayjs": "^1.11.15",
         "mobx": "^6.13.7",
         "mobx-react-lite": "^4.1.0",
         "mobx-state-tree": "^6.0.1",
@@ -1765,6 +1766,12 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.15",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.15.tgz",
+      "integrity": "sha512-MC+DfnSWiM9APs7fpiurHGCoeIx0Gdl6QZBy+5lu8MbYKN5FZEXqOgrundfibdfhGZ15o9hzmZ2xJjZnbvgKXQ==",
       "license": "MIT"
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "axios": "^1.11.0",
+    "dayjs": "^1.11.15",
     "mobx": "^6.13.7",
     "mobx-react-lite": "^4.1.0",
     "mobx-state-tree": "^6.0.1",

--- a/src/features/interface/InterfaceList.tsx
+++ b/src/features/interface/InterfaceList.tsx
@@ -1,9 +1,10 @@
 import { useEffect } from 'react'
 import { observer } from 'mobx-react-lite'
-import { Item } from 'semantic-ui-react'
+import { Item, Segment } from 'semantic-ui-react'
 
 import ProgramCard from '../../components/ProgramCard'
 import { useRootStore } from '../../models'
+import { getFullDate } from '../../utils/date'
 
 const InterfaceList = observer(() => {
   const { interfaceStore } = useRootStore()
@@ -13,16 +14,18 @@ const InterfaceList = observer(() => {
   }, [interfaceStore])
 
   return (
-    <Item.Group>
-      {interfaceStore.data.map(item => (
-        <ProgramCard
-          key={item.id}
-          date={item.modification_time}
-          title={item.title}
-          to={`/interface/${item.id}/program`}
-        />
-      ))}
-    </Item.Group>
+    <Segment>
+      <Item.Group divided>
+        {interfaceStore.data.map(item => (
+          <ProgramCard
+            key={item.id}
+            date={getFullDate(item.modification_time)}
+            title={item.title}
+            to={`/interface/${item.id}/program`}
+          />
+        ))}
+      </Item.Group>
+    </Segment>
   )
 })
 

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,3 @@
+import dayjs from 'dayjs'
+export const getFullDate = (d: string) =>
+  dayjs(d).format('DD.MM.YYYY HH:mm:ss')


### PR DESCRIPTION
## Summary
- add dayjs for consistent date formatting
- show interface modification dates in `DD.MM.YYYY HH:mm:ss`
- wrap interface list in a segment to restore semantic UI frame

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b150d369a08330984f8aaab4ef577b