### PR TITLE
Use hash-based routing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,0 @@
-import { RouterProvider } from 'react-router-dom'
-import router from './router'
-
-function App() {
-  return <RouterProvider router={router} />
-}
-
-export default App

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,7 +2,8 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import 'semantic-ui-css/semantic.min.css'
 import './index.css'
-import App from './App.tsx'
+import { RouterProvider } from 'react-router-dom'
+import router from './router'
 import { RootStoreProvider } from './models'
 import ErrorBoundary from './components/ErrorBoundary'
 
@@ -10,7 +11,7 @@ createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <ErrorBoundary>
       <RootStoreProvider>
-        <App />
+        <RouterProvider router={router} />
       </RootStoreProvider>
     </ErrorBoundary>
   </StrictMode>,

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,8 +1,7 @@
-import { createBrowserRouter, Navigate } from 'react-router-dom'
-import React from 'react'
+import { createHashRouter, Navigate } from 'react-router-dom'
 import InterfaceList from './features/interface/InterfaceList'
 
-const router = createBrowserRouter([
+const router = createHashRouter([
   {
     path: '/',
     element: <Navigate to="/interface" replace />,


### PR DESCRIPTION
## Summary
- switch router to `createHashRouter` for hash-based URLs
- render `RouterProvider` at the root

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b15bf879b48330b950b245094e4967