### PR TITLE
Add program store and list route

### DIFF
--- a/src/features/program/ProgramList.tsx
+++ b/src/features/program/ProgramList.tsx
@@ -1,0 +1,37 @@
+import { useEffect } from 'react'
+import { useParams } from 'react-router-dom'
+import { observer } from 'mobx-react-lite'
+import { Item, Segment } from 'semantic-ui-react'
+
+import ProgramCard from '../../components/ProgramCard'
+import { useProgramStore } from '../../models'
+import { getFullDate } from '../../utils/date'
+
+const ProgramList = observer(() => {
+  const { interfaceId } = useParams()
+  const programStore = useProgramStore()
+
+  useEffect(() => {
+    if (interfaceId) {
+      programStore.fetch(Number(interfaceId))
+    }
+  }, [interfaceId, programStore])
+
+  return (
+    <Segment>
+      <Item.Group divided>
+        {programStore.data.map(item => (
+          <ProgramCard
+            key={item.id}
+            date={getFullDate(item.modification_time)}
+            title={item.title}
+            to={`/interface/${interfaceId}/program/${item.id}/version`}
+          />
+        ))}
+      </Item.Group>
+    </Segment>
+  )
+})
+
+export default ProgramList
+

--- a/src/models/Program.ts
+++ b/src/models/Program.ts
@@ -1,0 +1,49 @@
+import { types, flow, cast, Instance, SnapshotIn } from 'mobx-state-tree'
+import { callApi } from '../utils/api'
+
+export const ProgramDataItemModel = types.model('ProgramDataItem', {
+  id: types.number,
+  code: types.string,
+  creation_time: types.string,
+  environment: types.maybeNull(types.number),
+  modification_time: types.string,
+  program_interface: types.number,
+  title: types.string,
+  url: types.string,
+})
+
+export interface ProgramDataItem extends Instance<typeof ProgramDataItemModel> {}
+export interface ProgramDataItemSnapshot extends SnapshotIn<typeof ProgramDataItemModel> {}
+
+export const ProgramStoreModel = types
+  .model('ProgramStore', {
+    isFetching: types.boolean,
+    error: types.maybeNull(types.string),
+    data: types.array(ProgramDataItemModel),
+  })
+  .actions(self => ({
+    setData(data: ProgramDataItemSnapshot[]) {
+      self.data = cast(data)
+    },
+    setFetching(fetchState: boolean) {
+      self.isFetching = fetchState
+    },
+    setError(error: string | null) {
+      self.error = error
+    },
+    fetch: flow(function* fetch(interfaceId: number) {
+      try {
+        yield callApi<{ results: ProgramDataItemSnapshot[] }>({
+          url: `/rest/program?program_interface=${interfaceId}`,
+          onRequest: () => self.setFetching(true),
+          onSuccess: json => self.setData(json.results ?? []),
+          onError: err => self.setError(err),
+        })
+      } finally {
+        self.setFetching(false)
+      }
+    }),
+  }))
+
+export interface ProgramStore extends Instance<typeof ProgramStoreModel> {}
+

--- a/src/models/index.tsx
+++ b/src/models/index.tsx
@@ -3,10 +3,12 @@ import { useLocalObservable } from 'mobx-react-lite'
 
 import { RouterStore } from './Router'
 import { InterfaceStoreModel, InterfaceStore } from './Interface'
+import { ProgramStoreModel, ProgramStore } from './Program'
 
 export interface RootStore {
   router: RouterStore
   interfaceStore: InterfaceStore
+  programStore: ProgramStore
 }
 
 const RootStoreContext = createContext<RootStore | null>(null)
@@ -15,6 +17,11 @@ export function RootStoreProvider({ children }: { children: ReactNode }) {
   const store = useLocalObservable<RootStore>(() => ({
     router: new RouterStore(),
     interfaceStore: InterfaceStoreModel.create({
+      isFetching: false,
+      error: null,
+      data: [],
+    }),
+    programStore: ProgramStoreModel.create({
       isFetching: false,
       error: null,
       data: [],
@@ -35,4 +42,8 @@ export function useRootStore(): RootStore {
 
 export function useInterfaceStore(): InterfaceStore {
   return useRootStore().interfaceStore
+}
+
+export function useProgramStore(): ProgramStore {
+  return useRootStore().programStore
 }

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,5 +1,6 @@
 import { createHashRouter, Navigate } from 'react-router-dom'
 import InterfaceList from './features/interface/InterfaceList'
+import ProgramList from './features/program/ProgramList'
 
 const router = createHashRouter([
   {
@@ -9,6 +10,10 @@ const router = createHashRouter([
   {
     path: '/interface',
     element: <InterfaceList />,
+  },
+  {
+    path: '/interface/:interfaceId/program',
+    element: <ProgramList />,
   },
 ])
 


### PR DESCRIPTION
## Summary
- add typed Program store with API fetch
- render ProgramList linked to interface programs
- wire program store into root provider and router

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b15fdada688330b9001ed5a6c2d2a4