### PR TITLE
Add version store and version list

### DIFF
--- a/src/components/VersionCard.tsx
+++ b/src/components/VersionCard.tsx
@@ -1,0 +1,20 @@
+import { Link } from 'react-router-dom'
+import { Item, Icon } from 'semantic-ui-react'
+
+interface VersionCardProps {
+  title: string
+  description: string
+  to: string
+}
+
+const VersionCard = ({ title, description, to }: VersionCardProps) => (
+  <Item>
+    <Icon name='file text' color='blue' />
+    <Item.Content>
+      <Link to={to}>{title}</Link>
+      <Item.Description>{description}</Item.Description>
+    </Item.Content>
+  </Item>
+)
+
+export default VersionCard

--- a/src/features/version/VersionList.tsx
+++ b/src/features/version/VersionList.tsx
@@ -1,0 +1,35 @@
+import { useEffect } from 'react'
+import { useParams } from 'react-router-dom'
+import { observer } from 'mobx-react-lite'
+import { Item, Segment } from 'semantic-ui-react'
+
+import VersionCard from '../../components/VersionCard'
+import { useVersionStore } from '../../models'
+
+const VersionList = observer(() => {
+  const { interfaceId, programId } = useParams()
+  const versionStore = useVersionStore()
+
+  useEffect(() => {
+    if (programId) {
+      versionStore.fetch(Number(programId))
+    }
+  }, [programId, versionStore])
+
+  return (
+    <Segment>
+      <Item.Group divided>
+        {versionStore.data.map(item => (
+          <VersionCard
+            key={item.id}
+            title={item.title}
+            description={item.description}
+            to={`/interface/${interfaceId}/program/${programId}/version/${item.id}`}
+          />
+        ))}
+      </Item.Group>
+    </Segment>
+  )
+})
+
+export default VersionList

--- a/src/models/Version.ts
+++ b/src/models/Version.ts
@@ -1,0 +1,49 @@
+import { types, flow, cast, Instance, SnapshotIn } from 'mobx-state-tree'
+import { callApi } from '../utils/api'
+
+export const VersionDataItemModel = types.model('VersionDataItem', {
+  id: types.number,
+  creation_time: types.string,
+  environment: types.maybeNull(types.number),
+  modification_time: types.string,
+  title: types.string,
+  url: types.string,
+  description: types.string,
+  is_default: types.boolean,
+  program: types.number,
+})
+
+export interface VersionDataItem extends Instance<typeof VersionDataItemModel> {}
+export interface VersionDataItemSnapshot extends SnapshotIn<typeof VersionDataItemModel> {}
+
+export const VersionStoreModel = types
+  .model('VersionStore', {
+    isFetching: types.boolean,
+    error: types.maybeNull(types.string),
+    data: types.array(VersionDataItemModel),
+  })
+  .actions(self => ({
+    setData(data: VersionDataItemSnapshot[]) {
+      self.data = cast(data)
+    },
+    setFetching(fetchState: boolean) {
+      self.isFetching = fetchState
+    },
+    setError(error: string | null) {
+      self.error = error
+    },
+    fetch: flow(function* fetch(programId: number) {
+      try {
+        yield callApi<{ results: VersionDataItemSnapshot[] }>({
+          url: `/rest/program-version?program=${programId}`,
+          onRequest: () => self.setFetching(true),
+          onSuccess: json => self.setData(json.results ?? []),
+          onError: err => self.setError(err),
+        })
+      } finally {
+        self.setFetching(false)
+      }
+    }),
+  }))
+
+export interface VersionStore extends Instance<typeof VersionStoreModel> {}

--- a/src/models/index.tsx
+++ b/src/models/index.tsx
@@ -4,11 +4,13 @@ import { useLocalObservable } from 'mobx-react-lite'
 import { RouterStore } from './Router'
 import { InterfaceStoreModel, InterfaceStore } from './Interface'
 import { ProgramStoreModel, ProgramStore } from './Program'
+import { VersionStoreModel, VersionStore } from './Version'
 
 export interface RootStore {
   router: RouterStore
   interfaceStore: InterfaceStore
   programStore: ProgramStore
+  versionStore: VersionStore
 }
 
 const RootStoreContext = createContext<RootStore | null>(null)
@@ -22,6 +24,11 @@ export function RootStoreProvider({ children }: { children: ReactNode }) {
       data: [],
     }),
     programStore: ProgramStoreModel.create({
+      isFetching: false,
+      error: null,
+      data: [],
+    }),
+    versionStore: VersionStoreModel.create({
       isFetching: false,
       error: null,
       data: [],
@@ -46,4 +53,8 @@ export function useInterfaceStore(): InterfaceStore {
 
 export function useProgramStore(): ProgramStore {
   return useRootStore().programStore
+}
+
+export function useVersionStore(): VersionStore {
+  return useRootStore().versionStore
 }

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,6 +1,7 @@
 import { createHashRouter, Navigate } from 'react-router-dom'
 import InterfaceList from './features/interface/InterfaceList'
 import ProgramList from './features/program/ProgramList'
+import VersionList from './features/version/VersionList'
 
 const router = createHashRouter([
   {
@@ -14,6 +15,10 @@ const router = createHashRouter([
   {
     path: '/interface/:interfaceId/program',
     element: <ProgramList />,
+  },
+  {
+    path: '/interface/:interfaceId/program/:programId/version',
+    element: <VersionList />,
   },
 ])
 


### PR DESCRIPTION
## Summary
- add MST Version store for program versions
- render version list with new VersionCard component
- wire up version route and store in root

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b160efb1f483309b98a7a8f4829331