### PR TITLE
Add ProgramVersion MST model and view integration

### DIFF
--- a/src/features/program-version/ProgramVersionView.tsx
+++ b/src/features/program-version/ProgramVersionView.tsx
@@ -3,19 +3,27 @@ import { useParams } from 'react-router-dom'
 import { observer } from 'mobx-react-lite'
 import { Segment, Header, List, Icon } from 'semantic-ui-react'
 
-import { useVersionStore } from '../../models'
+import { useProgramVersionStore } from '../../models'
 
 const ProgramVersionView = observer(() => {
-  const { programId, versionId } = useParams()
-  const versionStore = useVersionStore()
+  const { versionId } = useParams()
+  const programVersionStore = useProgramVersionStore()
 
   useEffect(() => {
-    if (programId && versionStore.data.length === 0) {
-      versionStore.fetch(Number(programId))
+    if (versionId) {
+      programVersionStore.fetch(Number(versionId))
     }
-  }, [programId, versionStore])
+  }, [versionId, programVersionStore])
 
-  const version = versionStore.data.find(v => v.id === Number(versionId))
+  const { isFetching, error, data: version } = programVersionStore
+
+  if (isFetching) {
+    return <Segment>Loading...</Segment>
+  }
+
+  if (error) {
+    return <Segment>Error: {error}</Segment>
+  }
 
   if (!version) {
     return <Segment>Version not found</Segment>
@@ -28,6 +36,10 @@ const ProgramVersionView = observer(() => {
         <List.Item>
           <List.Header>Description</List.Header>
           {version.description}
+        </List.Item>
+        <List.Item>
+          <List.Header>XML</List.Header>
+          <pre>{version.xml}</pre>
         </List.Item>
         <List.Item>
           <List.Header>Is Default</List.Header>

--- a/src/models/ProgramVersion.ts
+++ b/src/models/ProgramVersion.ts
@@ -1,0 +1,52 @@
+import { types, flow, cast, Instance, SnapshotIn } from 'mobx-state-tree'
+import { callApi } from '../utils/api'
+
+export const ProgramVersionModel = types.model('ProgramVersion', {
+  id: types.number,
+  title: types.string,
+  description: types.string,
+  xml: types.maybeNull(types.string),
+  creation_time: types.string,
+  modification_time: types.string,
+  environment: types.maybeNull(types.number),
+  is_default: types.boolean,
+  program: types.number,
+  url: types.string,
+})
+
+export interface ProgramVersion extends Instance<typeof ProgramVersionModel> {}
+export interface ProgramVersionSnapshot extends SnapshotIn<typeof ProgramVersionModel> {}
+
+export const ProgramVersionStoreModel = types
+  .model('ProgramVersionStore', {
+    isFetching: types.boolean,
+    error: types.maybeNull(types.string),
+    data: types.maybeNull(ProgramVersionModel),
+  })
+  .actions(self => ({
+    setData(data: ProgramVersionSnapshot | null) {
+      // cast is used to ensure the data conforms to the model type
+      self.data = data ? cast(data) : null
+    },
+    setFetching(fetchState: boolean) {
+      self.isFetching = fetchState
+    },
+    setError(error: string | null) {
+      self.error = error
+    },
+    fetch: flow(function* fetch(versionId: number) {
+      try {
+        yield callApi<ProgramVersionSnapshot>({
+          url: `/rest/program-version/${versionId}`,
+          onRequest: () => self.setFetching(true),
+          onSuccess: json => self.setData(json),
+          onError: err => self.setError(err),
+        })
+      } finally {
+        self.setFetching(false)
+      }
+    }),
+  }))
+
+export interface ProgramVersionStore extends Instance<typeof ProgramVersionStoreModel> {}
+

--- a/src/models/index.tsx
+++ b/src/models/index.tsx
@@ -4,11 +4,13 @@ import { useLocalObservable } from 'mobx-react-lite'
 import { InterfaceStoreModel, InterfaceStore } from './Interface'
 import { ProgramStoreModel, ProgramStore } from './Program'
 import { VersionStoreModel, VersionStore } from './Version'
+import { ProgramVersionStoreModel, ProgramVersionStore } from './ProgramVersion'
 
 export interface RootStore {
   interfaceStore: InterfaceStore
   programStore: ProgramStore
   versionStore: VersionStore
+  programVersionStore: ProgramVersionStore
 }
 
 const RootStoreContext = createContext<RootStore | null>(null)
@@ -29,6 +31,11 @@ export function RootStoreProvider({ children }: { children: ReactNode }) {
       isFetching: false,
       error: null,
       data: [],
+    }),
+    programVersionStore: ProgramVersionStoreModel.create({
+      isFetching: false,
+      error: null,
+      data: null,
     }),
   }))
   return (
@@ -54,4 +61,8 @@ export function useProgramStore(): ProgramStore {
 
 export function useVersionStore(): VersionStore {
   return useRootStore().versionStore
+}
+
+export function useProgramVersionStore(): ProgramVersionStore {
+  return useRootStore().programVersionStore
 }


### PR DESCRIPTION
## Summary
- add ProgramVersion model and store for fetching version details
- wire programVersionStore into root store and expose hook
- update ProgramVersionView to load a version via programVersionStore and display XML

## Testing
- `npm test` *(fails: Cannot find module 'webpack/lib/ProvidePlugin' etc.)*
- `npx eslint src` *(fails: files are ignored)*

------
https://chatgpt.com/codex/tasks/task_e_68b17678c4ac833084f49ab624d23426