### PR TITLE
Add home page and breadcrumbs navigation

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,0 +1,36 @@
+import { Outlet, Link, useMatches } from 'react-router-dom'
+import { Breadcrumb, Container } from 'semantic-ui-react'
+
+const Layout = () => {
+  const matches = useMatches()
+  const breadcrumbs = matches
+    .filter(match => match.handle && (match.handle as any).crumb)
+    .map(match => ({
+      crumb: typeof (match.handle as any).crumb === 'function'
+        ? (match.handle as any).crumb(match.data)
+        : (match.handle as any).crumb,
+      pathname: match.pathname || ''
+    }))
+
+  return (
+    <Container style={{ marginTop: '1em' }}>
+      <Breadcrumb>
+        {breadcrumbs.map((bc, index) => (
+          <span key={bc.pathname}>
+            <Breadcrumb.Section
+              as={Link}
+              to={bc.pathname}
+              active={index === breadcrumbs.length - 1}
+            >
+              {bc.crumb}
+            </Breadcrumb.Section>
+            {index < breadcrumbs.length - 1 && <Breadcrumb.Divider icon='right angle' />}
+          </span>
+        ))}
+      </Breadcrumb>
+      <Outlet />
+    </Container>
+  )
+}
+
+export default Layout

--- a/src/features/execution/ExecutionList.tsx
+++ b/src/features/execution/ExecutionList.tsx
@@ -1,0 +1,7 @@
+import { Segment } from 'semantic-ui-react'
+
+const ExecutionList = () => (
+  <Segment>Logs placeholder</Segment>
+)
+
+export default ExecutionList

--- a/src/features/home/HomePage.tsx
+++ b/src/features/home/HomePage.tsx
@@ -1,0 +1,25 @@
+import { Card, Icon } from 'semantic-ui-react'
+import { Link } from 'react-router-dom'
+
+const HomePage = () => (
+  <Card.Group itemsPerRow={2} stackable>
+    <Card as={Link} to='/interface'>
+      <Card.Content>
+        <Card.Header>
+          <Icon name='folder open' /> Interfaces
+        </Card.Header>
+        <Card.Description>List of program interfaces.</Card.Description>
+      </Card.Content>
+    </Card>
+    <Card as={Link} to='/execution'>
+      <Card.Content>
+        <Card.Header>
+          <Icon name='bolt' /> Execution
+        </Card.Header>
+        <Card.Description>List of calculation logs.</Card.Description>
+      </Card.Content>
+    </Card>
+  </Card.Group>
+)
+
+export default HomePage

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,29 +1,48 @@
-import { createHashRouter, Navigate } from 'react-router-dom'
+import { createHashRouter } from 'react-router-dom'
+import Layout from './components/Layout'
+import HomePage from './features/home/HomePage'
 import InterfaceList from './features/interface/InterfaceList'
 import ProgramList from './features/program/ProgramList'
 import VersionList from './features/version/VersionList'
 import ProgramVersionView from './features/program-version/ProgramVersionView'
+import ExecutionList from './features/execution/ExecutionList'
 
 const router = createHashRouter([
   {
     path: '/',
-    element: <Navigate to="/interface" replace />,
-  },
-  {
-    path: '/interface',
-    element: <InterfaceList />,
-  },
-  {
-    path: '/interface/:interfaceId/program',
-    element: <ProgramList />,
-  },
-  {
-    path: '/interface/:interfaceId/program/:programId/version',
-    element: <VersionList />,
-  },
-  {
-    path: '/interface/:interfaceId/program/:programId/version/:versionId',
-    element: <ProgramVersionView />,
+    element: <Layout />,
+    children: [
+      {
+        index: true,
+        element: <HomePage />,
+        handle: { crumb: () => 'Home' },
+      },
+      {
+        path: 'interface',
+        element: <InterfaceList />,
+        handle: { crumb: () => 'Interfaces' },
+      },
+      {
+        path: 'interface/:interfaceId/program',
+        element: <ProgramList />,
+        handle: { crumb: () => 'Programs' },
+      },
+      {
+        path: 'interface/:interfaceId/program/:programId/version',
+        element: <VersionList />,
+        handle: { crumb: () => 'Versions' },
+      },
+      {
+        path: 'interface/:interfaceId/program/:programId/version/:versionId',
+        element: <ProgramVersionView />,
+        handle: { crumb: () => 'Program Version' },
+      },
+      {
+        path: 'execution',
+        element: <ExecutionList />,
+        handle: { crumb: () => 'Execution' },
+      },
+    ],
   },
 ])
 


### PR DESCRIPTION
## Summary
- Add layout with breadcrumb navigation across pages
- Introduce home page with links to interfaces and execution log
- Stub execution log page

## Testing
- `npm test` *(fails: Cannot find module 'webpack/lib/ProvidePlugin', etc.)*
- `npm run lint` *(fails: parsing errors in legacy files)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b178a52a288330b7a479d42df08923