### PR TITLE
feat: improve breadcrumbs hierarchy

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -7,7 +7,7 @@ const Layout = () => {
     .filter(match => match.handle && (match.handle as any).crumb)
     .map(match => ({
       crumb: typeof (match.handle as any).crumb === 'function'
-        ? (match.handle as any).crumb(match.data)
+        ? (match.handle as any).crumb(match)
         : (match.handle as any).crumb,
       pathname: match.pathname || ''
     }))

--- a/src/components/breadcrumbs.tsx
+++ b/src/components/breadcrumbs.tsx
@@ -1,0 +1,41 @@
+import { FC, useEffect } from 'react'
+import { useInterfaceStore, useProgramStore, useProgramVersionStore } from '../models'
+
+export const InterfaceCrumb: FC<{ interfaceId?: string }> = ({ interfaceId }) => {
+  const interfaceStore = useInterfaceStore()
+
+  useEffect(() => {
+    if (interfaceId && !interfaceStore.data.find(i => i.id === Number(interfaceId))) {
+      interfaceStore.fetch()
+    }
+  }, [interfaceId, interfaceStore])
+
+  const item = interfaceStore.data.find(i => i.id === Number(interfaceId))
+  return <>{item ? item.title : ''}</>
+}
+
+export const ProgramCrumb: FC<{ interfaceId?: string; programId?: string }> = ({ interfaceId, programId }) => {
+  const programStore = useProgramStore()
+
+  useEffect(() => {
+    if (interfaceId && programId && !programStore.data.find(p => p.id === Number(programId))) {
+      programStore.fetch(Number(interfaceId))
+    }
+  }, [interfaceId, programId, programStore])
+
+  const item = programStore.data.find(p => p.id === Number(programId))
+  return <>{item ? item.title : ''}</>
+}
+
+export const VersionCrumb: FC<{ versionId?: string }> = ({ versionId }) => {
+  const programVersionStore = useProgramVersionStore()
+
+  useEffect(() => {
+    if (versionId && programVersionStore.data?.id !== Number(versionId)) {
+      programVersionStore.fetch(Number(versionId))
+    }
+  }, [versionId, programVersionStore])
+
+  return <>{programVersionStore.data?.title ?? ''}</>
+}
+

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,4 +1,4 @@
-import { createHashRouter } from 'react-router-dom'
+import { createHashRouter, Outlet } from 'react-router-dom'
 import Layout from './components/Layout'
 import HomePage from './features/home/HomePage'
 import InterfaceList from './features/interface/InterfaceList'
@@ -6,41 +6,79 @@ import ProgramList from './features/program/ProgramList'
 import VersionList from './features/version/VersionList'
 import ProgramVersionView from './features/program-version/ProgramVersionView'
 import ExecutionList from './features/execution/ExecutionList'
+import { InterfaceCrumb, ProgramCrumb, VersionCrumb } from './components/breadcrumbs'
 
 const router = createHashRouter([
   {
     path: '/',
     element: <Layout />,
+    handle: { crumb: () => 'Home' },
     children: [
       {
         index: true,
         element: <HomePage />,
-        handle: { crumb: () => 'Home' },
       },
       {
         path: 'interface',
-        element: <InterfaceList />,
+        element: <Outlet />,
         handle: { crumb: () => 'Interfaces' },
-      },
-      {
-        path: 'interface/:interfaceId/program',
-        element: <ProgramList />,
-        handle: { crumb: () => 'Programs' },
-      },
-      {
-        path: 'interface/:interfaceId/program/:programId/version',
-        element: <VersionList />,
-        handle: { crumb: () => 'Versions' },
-      },
-      {
-        path: 'interface/:interfaceId/program/:programId/version/:versionId',
-        element: <ProgramVersionView />,
-        handle: { crumb: () => 'Program Version' },
+        children: [
+          {
+            index: true,
+            element: <InterfaceList />,
+          },
+          {
+            path: ':interfaceId',
+            element: <Outlet />,
+            handle: (match: any) => <InterfaceCrumb interfaceId={match.params.interfaceId} />,
+            children: [
+              {
+                path: 'program',
+                element: <Outlet />,
+                children: [
+                  {
+                    index: true,
+                    element: <ProgramList />,
+                  },
+                  {
+                    path: ':programId',
+                    element: <Outlet />,
+                    handle: (match: any) => (
+                      <ProgramCrumb
+                        interfaceId={match.params.interfaceId}
+                        programId={match.params.programId}
+                      />
+                    ),
+                    children: [
+                      {
+                        path: 'version',
+                        element: <Outlet />,
+                        children: [
+                          {
+                            index: true,
+                            element: <VersionList />,
+                          },
+                          {
+                            path: ':versionId',
+                            element: <ProgramVersionView />,
+                            handle: (match: any) => (
+                              <VersionCrumb versionId={match.params.versionId} />
+                            ),
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
       },
       {
         path: 'execution',
         element: <ExecutionList />,
-        handle: { crumb: () => 'Execution' },
+        handle: { crumb: () => 'Logs' },
       },
     ],
   },


### PR DESCRIPTION
## Summary
- make breadcrumbs hierarchical using nested routes
- add dynamic crumbs for interfaces, programs and versions
- show Logs instead of Execution in breadcrumb

## Testing
- `npm test` *(fails: Parse failure & missing modules in legacy tests)*
- `npx vitest run src/features/interface/InterfaceList.test.tsx`
- `npm run lint` *(fails: files in "src" are ignored)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b17dac6a3c8330ac2b9962a1d5b255