### PR TITLE
Add ProgramVersionStore test and configure Vitest

### DIFF
--- a/src/features/program-version/__tests__/ProgramVersionStore.test.ts
+++ b/src/features/program-version/__tests__/ProgramVersionStore.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ProgramVersionStoreModel } from '../../../models/ProgramVersion'
+import mockVersion from '../__mocks__/programVersion.json'
+
+// Mock the API call used in ProgramVersionStore
+vi.mock('../../../utils/api', () => ({
+  callApi: ({ onRequest, onSuccess }: any) => {
+    onRequest?.()
+    onSuccess?.({ ...mockVersion, url: '/rest/program-version/1/' })
+    return Promise.resolve()
+  },
+}))
+
+describe('ProgramVersionStore', () => {
+  it('fetches and stores program version data', async () => {
+    const store = ProgramVersionStoreModel.create({
+      isFetching: false,
+      error: null,
+      data: null,
+    })
+
+    await store.fetch(1)
+
+    expect(store.isFetching).toBe(false)
+    expect(store.error).toBeNull()
+    expect(store.data?.id).toBe(mockVersion.id)
+    expect(store.data?.title).toBe(mockVersion.title)
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,6 +16,6 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
-    exclude: ['node_modules/**', 'dist/**', 'cypress/**', 'old/**'],
+    exclude: ['node_modules/**', 'dist/**', 'cypress/**', 'old/**', 'old-v1/**', 'old-v2/**'],
   },
 })


### PR DESCRIPTION
## Summary
- add fixture-based test for ProgramVersionStore
- configure vitest to ignore legacy old-v1/old-v2 tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b188d904d88330a7c8ca3a39e97ec8