### PR TITLE
Fix breadcrumb path generation and add tests

### DIFF
--- a/src/components/__tests__/Breadcrumbs.test.tsx
+++ b/src/components/__tests__/Breadcrumbs.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from '@testing-library/react'
+import { vi } from 'vitest'
+import { createMemoryRouter, RouterProvider } from 'react-router-dom'
+import '@testing-library/jest-dom'
+
+import { routes } from '../../router'
+
+let mockRootStore: any
+vi.mock('../../models', () => ({
+  useInterfaceStore: () => mockRootStore.interfaceStore,
+  useProgramStore: () => mockRootStore.programStore,
+  useProgramVersionStore: () => mockRootStore.programVersionStore,
+  useRootStore: () => mockRootStore,
+}))
+
+describe('Breadcrumbs', () => {
+  beforeEach(() => {
+    mockRootStore = {
+      interfaceStore: {
+        data: [],
+        fetch: vi.fn(),
+      },
+      programStore: {
+        data: [],
+        fetch: vi.fn(),
+      },
+      programVersionStore: {
+        data: null,
+        fetch: vi.fn(),
+      },
+    }
+  })
+
+  it('shows breadcrumb for interface list', () => {
+    const router = createMemoryRouter(routes, { initialEntries: ['/interface'] })
+    render(<RouterProvider router={router} />)
+    expect(screen.getByText('Home')).toBeInTheDocument()
+    expect(screen.getByText('Interfaces')).toBeInTheDocument()
+  })
+
+  it('shows breadcrumb for program list', () => {
+    mockRootStore.interfaceStore.data = [
+      { id: 1, title: 'Interface 1' },
+    ]
+    const router = createMemoryRouter(routes, { initialEntries: ['/interface/1/program'] })
+    render(<RouterProvider router={router} />)
+    expect(screen.getByText('Home')).toBeInTheDocument()
+    expect(screen.getByText('Interfaces')).toBeInTheDocument()
+    expect(screen.getByText('Interface 1')).toBeInTheDocument()
+  })
+
+  it('shows breadcrumb for program version view', () => {
+    mockRootStore.interfaceStore.data = [
+      { id: 1, title: 'Interface 1' },
+    ]
+    mockRootStore.programStore.data = [
+      { id: 2, title: 'Program A' },
+    ]
+    mockRootStore.programVersionStore.data = { id: 3, title: 'Version 1' }
+    const router = createMemoryRouter(routes, { initialEntries: ['/interface/1/program/2/version/3'] })
+    render(<RouterProvider router={router} />)
+    expect(screen.getByText('Home')).toBeInTheDocument()
+    expect(screen.getByText('Interfaces')).toBeInTheDocument()
+    expect(screen.getByText('Interface 1')).toBeInTheDocument()
+    expect(screen.getByText('Program A')).toBeInTheDocument()
+    expect(screen.getAllByText('Version 1')[0]).toBeInTheDocument()
+  })
+
+  it('shows breadcrumb for logs', () => {
+    const router = createMemoryRouter(routes, { initialEntries: ['/execution'] })
+    render(<RouterProvider router={router} />)
+    expect(screen.getByText('Home')).toBeInTheDocument()
+    expect(screen.getByText('Logs')).toBeInTheDocument()
+  })
+})

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -8,7 +8,7 @@ import ProgramVersionView from './features/program-version/ProgramVersionView'
 import ExecutionList from './features/execution/ExecutionList'
 import { InterfaceCrumb, ProgramCrumb, VersionCrumb } from './components/breadcrumbs'
 
-const router = createHashRouter([
+export const routes = [
   {
     path: '/',
     element: <Layout />,
@@ -30,7 +30,11 @@ const router = createHashRouter([
           {
             path: ':interfaceId',
             element: <Outlet />,
-            handle: (match: any) => <InterfaceCrumb interfaceId={match.params.interfaceId} />,
+            handle: {
+              crumb: (match: any) => (
+                <InterfaceCrumb interfaceId={match.params.interfaceId} />
+              ),
+            },
             children: [
               {
                 path: 'program',
@@ -43,12 +47,14 @@ const router = createHashRouter([
                   {
                     path: ':programId',
                     element: <Outlet />,
-                    handle: (match: any) => (
-                      <ProgramCrumb
-                        interfaceId={match.params.interfaceId}
-                        programId={match.params.programId}
-                      />
-                    ),
+                    handle: {
+                      crumb: (match: any) => (
+                        <ProgramCrumb
+                          interfaceId={match.params.interfaceId}
+                          programId={match.params.programId}
+                        />
+                      ),
+                    },
                     children: [
                       {
                         path: 'version',
@@ -61,9 +67,11 @@ const router = createHashRouter([
                           {
                             path: ':versionId',
                             element: <ProgramVersionView />,
-                            handle: (match: any) => (
-                              <VersionCrumb versionId={match.params.versionId} />
-                            ),
+                            handle: {
+                              crumb: (match: any) => (
+                                <VersionCrumb versionId={match.params.versionId} />
+                              ),
+                            },
                           },
                         ],
                       },
@@ -82,6 +90,8 @@ const router = createHashRouter([
       },
     ],
   },
-])
+]
+
+const router = createHashRouter(routes)
 
 export default router


### PR DESCRIPTION
## Summary
- ensure router exposes full breadcrumb hierarchy with dynamic titles
- add unit tests covering interface, program, version, and logs breadcrumbs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1bf0a67448330a3d5cd20dbbdc0c3