### PR TITLE
Fix home page alignment

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -24,8 +24,6 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
 }


### PR DESCRIPTION
## Summary
- remove flex layout from body to prevent vertical centering

## Testing
- `npm test`
- `npx eslint src` *(fails: You are linting "src" but all of the files matching the glob pattern "src" are ignored)*

------
https://chatgpt.com/codex/tasks/task_e_68b32f113fc88330b3b673f16fb92b67