### PR TITLE
Fix breadcrumb navigation paths and add tests

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -5,12 +5,16 @@ const Layout = () => {
   const matches = useMatches()
   const breadcrumbs = matches
     .filter(match => match.handle && (match.handle as any).crumb)
-    .map(match => ({
-      crumb: typeof (match.handle as any).crumb === 'function'
-        ? (match.handle as any).crumb(match)
-        : (match.handle as any).crumb,
-      pathname: match.pathname || ''
-    }))
+    .map(match => {
+      const handle = match.handle as any
+      const crumb = typeof handle.crumb === 'function' ? handle.crumb(match) : handle.crumb
+      const pathname = handle.path
+        ? typeof handle.path === 'function'
+          ? handle.path(match)
+          : handle.path
+        : match.pathname || ''
+      return { crumb, pathname }
+    })
 
   return (
     <Container style={{ marginTop: '1em' }}>

--- a/src/components/__tests__/Breadcrumbs.test.tsx
+++ b/src/components/__tests__/Breadcrumbs.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { vi } from 'vitest'
 import { createMemoryRouter, RouterProvider } from 'react-router-dom'
 import '@testing-library/jest-dom'
@@ -9,6 +9,7 @@ let mockRootStore: any
 vi.mock('../../models', () => ({
   useInterfaceStore: () => mockRootStore.interfaceStore,
   useProgramStore: () => mockRootStore.programStore,
+  useVersionStore: () => mockRootStore.versionStore,
   useProgramVersionStore: () => mockRootStore.programVersionStore,
   useRootStore: () => mockRootStore,
 }))
@@ -26,6 +27,10 @@ describe('Breadcrumbs', () => {
       },
       programVersionStore: {
         data: null,
+        fetch: vi.fn(),
+      },
+      versionStore: {
+        data: [],
         fetch: vi.fn(),
       },
     }
@@ -71,5 +76,36 @@ describe('Breadcrumbs', () => {
     render(<RouterProvider router={router} />)
     expect(screen.getByText('Home')).toBeInTheDocument()
     expect(screen.getByText('Logs')).toBeInTheDocument()
+  })
+
+  it('renders program list when navigating via interface breadcrumb', async () => {
+    mockRootStore.interfaceStore.data = [
+      { id: 1, title: 'Interface 1' },
+    ]
+    mockRootStore.programStore.data = [
+      { id: 2, title: 'Program A' },
+    ]
+    mockRootStore.programVersionStore.data = { id: 3, title: 'Version 1' }
+    const router = createMemoryRouter(routes, { initialEntries: ['/interface/1/program/2/version/3'] })
+    render(<RouterProvider router={router} />)
+    fireEvent.click(screen.getByText('Interface 1'))
+    expect(await screen.findByText('Program A')).toBeInTheDocument()
+  })
+
+  it('renders version list when navigating via program breadcrumb', async () => {
+    mockRootStore.interfaceStore.data = [
+      { id: 1, title: 'Interface 1' },
+    ]
+    mockRootStore.programStore.data = [
+      { id: 2, title: 'Program A' },
+    ]
+    mockRootStore.versionStore.data = [
+      { id: 3, title: 'Version 1', description: '' },
+    ]
+    mockRootStore.programVersionStore.data = { id: 3, title: 'Version 1' }
+    const router = createMemoryRouter(routes, { initialEntries: ['/interface/1/program/2/version/3'] })
+    render(<RouterProvider router={router} />)
+    fireEvent.click(screen.getByText('Program A'))
+    expect(await screen.findByText('Version 1')).toBeInTheDocument()
   })
 })

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -34,6 +34,7 @@ export const routes = [
               crumb: (match: any) => (
                 <InterfaceCrumb interfaceId={match.params.interfaceId} />
               ),
+              path: (match: any) => `/interface/${match.params.interfaceId}/program`,
             },
             children: [
               {
@@ -54,6 +55,8 @@ export const routes = [
                           programId={match.params.programId}
                         />
                       ),
+                      path: (match: any) =>
+                        `/interface/${match.params.interfaceId}/program/${match.params.programId}/version`,
                     },
                     children: [
                       {


### PR DESCRIPTION
## Summary
- ensure breadcrumb links point to parent index routes
- add tests covering navigation via breadcrumb

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b33b7a671c8330affbb12fd4e65683